### PR TITLE
Added row divs as direct parents of column divs

### DIFF
--- a/assets/javascript/main.js
+++ b/assets/javascript/main.js
@@ -97,8 +97,6 @@ function NearestCity(latitude, longitude) {
     return a.dist - b.dist;
   });
 
-  console.log(closest);
-
   $.getJSON('assets/json/campsites2.json').then(function(data) {
     $("#closeCamps").append(
       `

--- a/assets/json/campsites2.json
+++ b/assets/json/campsites2.json
@@ -4828,7 +4828,7 @@
     "city": "Vellore",
     "state": "Tamil Nadu",
     "country": "India",
-    "coordinates": "43.833416, -79.557977",
+    "coordinates": "12.9657203,79.1454622",
     "photoUrl": ""
   },
   {

--- a/index.html
+++ b/index.html
@@ -93,43 +93,48 @@
     </div>
   </nav>
   <br>
-	<div class="container">
-    <div class="twelve columns offset-by-one content">
-			<div class="doc-section" id="guests">
-				<h3 class="intro center">You can join a nearby study group and code in-person together with other campers.</h3>
-			</div>
-      <br>
-      <p><strong>Step 1: </strong>Join the study group closest to you. (This page will request permission from your browser to know your location. Don't worry - your location data will never leave your browser window.)</p>
-      <br>
-		</div>
-    <div class="twelve columns offset-by-one content">
-      <div id="closeCamps">
 
+  <div class="container">
+    <div class="row">
+      <div class="eleven columns offset-by-one content">
+        <div class="doc-section" id="guests">
+          <h3 class="intro center">You can join a nearby study group and code in-person together with other campers.</h3>
+        </div>
+        <br>
+        <p><strong>Step 1: </strong>Join the study group closest to you. (This page will request permission from your browser to know your location. Don't worry - your location data will never leave your browser window.)</p>
+        <br>
       </div>
-		</div>
+    </div>
 
-    <div class="twelve columns offset-by-one content">
+    <div class="row">
+      <div class="eleven columns offset-by-one content">
+        <div id="closeCamps">
 
-      <p><strong>Step 2: </strong>Also join our <a href="https://www.facebook.com/groups/freeCodeCampEarth/" target="_blank">freeCodeCamp Earth study group</a>.</p>
-      <p><strong>Step 3: </strong>You can also join study groups in other cities you visit often. Search for them below. (If you can't find a study group that's close enough, <a href="https://forum.freecodecamp.com/t/how-to-create-a-local-group/19532" target="_blank">you can create one</a>).
-      <br>
+        </div>
+      </div>
+    </div>
 
-			<div class="doc-section" id="guests">
-        <form>
-          <input type="text" name="search" id="search" placeholder="Search for a city" class="big-search-field">
-        </form>
-        <p>
-        Results: <span id="res"></span>
-        </p>
-			</div>
-
-			<div class="row clearfix" id="guest-list">
-        <ul id="camps" class="camps">
-        </ul>
-        <div class="loader"></div>
-			</div>
-		</div>
-	</div>
+    <div class="row">
+      <div class="eleven columns offset-by-one content">
+        <p><strong>Step 2: </strong>Also join our <a href="https://www.facebook.com/groups/freeCodeCampEarth/" target="_blank">freeCodeCamp Earth study group</a>.</p>
+        <p><strong>Step 3: </strong>You can also join study groups in other cities you visit often. Search for them below. (If you can't find a study group that's close enough, <a href="https://forum.freecodecamp.com/t/how-to-create-a-local-group/19532" target="_blank">you can create one</a>).
+        <br>
+        <div class="doc-section" id="guests">
+          <form>
+            <input type="text" name="search" id="search" placeholder="Search for a city" class="big-search-field">
+          </form>
+          <p>
+          Results: <span id="res"></span>
+          </p>
+        </div>
+        <div class="row clearfix" id="guest-list">
+          <ul id="camps" class="camps">
+          </ul>
+          <div class="loader"></div>
+        </div>
+      </div>
+    </div>
+  </div>
 
 	<!-- JS -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>


### PR DESCRIPTION
As per Skeleton web site, column divs should be direct children of row divs. Also changed column numbers from "twelve" to "eleven". eleven plus one offset for a total of twelve. Lastly, deleted console.log() that I forgot to remove from my last commit. Sorry for that. =)

Update: Fixed #12, coordinates for Vellore, Tamil Nadu, India in `assets/json/campsites2.json` is incorrect.