### PR TITLE
Fix coordinates for Nevada County CA

### DIFF
--- a/assets/json/campsitesfinal.json
+++ b/assets/json/campsitesfinal.json
@@ -10196,7 +10196,7 @@
     "city": "Nevada County",
     "state": "California",
     "country": "United States",
-    "coordinates": "39.78373, -100.445882",
+    "coordinates": "39.269983, -121.026236",
     "photoUrl": ""
   },
   {


### PR DESCRIPTION
Old coordinates are somewhere in Kansas. Updates to the coordinates of the Nevada County, CA Govt. Center.