### PR TITLE
Fixes coordinates of Worcester, Massachusetts, USA

### DIFF
--- a/assets/json/campsitesfinal.json
+++ b/assets/json/campsitesfinal.json
@@ -7437,7 +7437,7 @@
     "state": "",
     "country": "Philippines",
     "coordinates": "14.590622, 120.97997",
-    "photoUrl": "https://scontent-dft4-2.xx.fbcdn.net/v/t31.0-8/16113216_10208153688820580_1043581039883651228_o.jpg?oh=f5dcf2be320488e233d631b25cfc58b9&oe=5954DD7D"
+    "photoUrl": "https://scontent.fmnl13-1.fna.fbcdn.net/v/t1.0-9/18199241_10210563063370531_9192704129359910881_n.jpg?oh=3faa7624840fd8c35c338cf7faa46e9f&oe=5A7E72D9"
   },
   {
     "url": "https://www.facebook.com/groups/free.code.camp.mati",

--- a/assets/json/campsitesfinal.json
+++ b/assets/json/campsitesfinal.json
@@ -11796,7 +11796,7 @@
     "city": "Worcester",
     "state": "Massachusetts",
     "country": "United States",
-    "coordinates": "52.191829, -2.221601",
+    "coordinates": "42.2755407, -71.8777779",
     "photoUrl": ""
   },
   {


### PR DESCRIPTION
**Fixes #53**
Fixed coordinates for Worcester, Massachusetts, USA. It somehow had the same coordinates as Worcester, England.