### PR TITLE
fix: correct url

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 This simple website is a catalog of all of the free code camp study groups around the world. The group closest to your browser location should be displayed at the top of the page. Feel free to search the rest of the locations by city name.
 
-[freeCodeCamp Study Groups](https://www.freecodecamp.org/study-group-directory/)
+[freeCodeCamp Study Groups](https://study-group-directory.freecodecamp.org/)


### PR DESCRIPTION
url points to old url for study group directory, replaced with correct one